### PR TITLE
Working on fixes related to tripal/tripal#1951 which are causes failed tests in Tripal extensions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           modules: tripal
           php-version: "8.3"
           pgsql-version: "16"
-          drupal-version: "10.4.x"
+          drupal-version: "10.4.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,30 @@ jobs:
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"
+  test_codeclimate:
+    name: "Run providing inputs needed for codeclimate coverage reporting"
+    runs-on: ubuntu-latest
+    steps:
+      # To use this repository's private action,
+      # you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Clone Tripal for testing purposes
+        run: |
+          git clone https://github.com/tripal/tripal.git tmp
+          cd tmp
+          git checkout 4.x
+          mv * ../
+          ls ../
+      - name: Run the action step
+        uses: ./ # Uses an action in the root directory
+        with:
+          directory-name: tripal
+          modules: tripal
+          php-version: "8.3"
+          pgsql-version: "16"
+          drupal-version: "10.4.x-dev"
+          phpunit-command-options: '--filter testTripalAdminPages'
+          build-image: true
+          dockerfile: "Dockerfile"
+          codeclimate-reporter-id: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,35 +42,9 @@ jobs:
         with:
           directory-name: tripal
           modules: tripal
-          php-version: "8.1"
-          pgsql-version: "13"
-          drupal-version: "10.0.x"
+          php-version: "8.3"
+          pgsql-version: "16"
+          drupal-version: "10.4.x"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
-          dockerfile: "tripaldocker/Dockerfile-php8.1-pgsql13"
-  test_dockfile_tripaldocker:
-    name: "Run Build Tripaldocker"
-    runs-on: ubuntu-latest
-    steps:
-      # To use this repository's private action,
-      # you must check out the repository
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Clone Tripal for testing purposes
-        run: |
-          git clone https://github.com/tripal/tripal.git tmp
-          cd tmp
-          git checkout 4.x
-          mv * ../
-          ls ../
-      - name: Run the action step
-        uses: ./ # Uses an action in the root directory
-        with:
-          directory-name: tripal
-          modules: tripal
-          php-version: "8.1"
-          pgsql-version: "13"
-          drupal-version: "10.0.x"
-          phpunit-command-options: '--filter testTripalAdminPages'
-          build-image: true
-          dockerfile: "UseTripalDockerBackupClause"
+          dockerfile: "Dockerfile"

--- a/README.md
+++ b/README.md
@@ -22,22 +22,16 @@ jobs:
           - "8.3"
         pgsql-version:
           - "13"
+          - "16"
         drupal-version:
-          - "10.0.x-dev"
-          - "10.1.x-dev"
           - "10.2.x-dev"
-        exclude:
-          - php-version: "8.3"
-            pgsql-version: "13"
-            drupal-version: "10.0.x-dev"
-          - php-version: "8.3"
-            pgsql-version: "13"
-            drupal-version: "10.1.x-dev"
+          - "10.3.x-dev"
+          - "10.4.x-dev"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Automated testing
-        uses: tripal/test-tripal-action@v1.3
+        uses: tripal/test-tripal-action@v1.6
         with:
           directory-name: my_tripal_extension
           modules: my_tripal_extension

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This repo provides a Github Action to make automated testing workflows for Tripa
 
 ## Example usage
 
-The following example for a module named `my_tripal_extension` uses this action in a matrix to automate testing across multiple php and drupal versions.
+The following examples for a module named `my_tripal_extension` uses this action in a matrix to automate testing across multiple php and drupal versions.
+
+### Basic Automated Testing
 
 ```yml
 name: PHPUnit
@@ -38,6 +40,38 @@ jobs:
           php-version: ${{ matrix.php-version }}
           pgsql-version: ${{ matrix.pgsql-version }}
           drupal-version: ${{ matrix.drupal-version }}
+```
+
+### CodeClimate Test Coverage
+
+The following example assumes you have setup PHPUnit to support test coverage reporting and registered your repo with CodeClimate Quality.
+
+Once that is complete, you can find the CodeClimate "Test Reporter ID" by going to Repo Settings > Test Coverage and copying the "Test Reporter ID" on the CodeClimate Quality page for your repo (i.e. https://codeclimate.com/github/[organization]/[repo]).
+
+This CodeClimate "Test Reporter ID" should then be saved as a secret in your repository on Github by going to Settings > Secrets and Variables > Actions on your repos github page (i.e. https://github.com/[organization]/[repo]/settings/secrets/actions) and adding a repository secret with a name of `CODECLIMATE_TEST_REPORTER_ID` and a value matching the CodeClimate "Test Reporter ID".
+
+Once you've completed those steps you can now create a workflow like the following which runs this action on a specific Drupal-PHP-PostgreSQL version (this should be the best supported version). This workflow uses the github secret as an arguement to this Github Action so that the generated clover.xml can be pushed to CodeClimate.
+
+You can confirm the workflow has worked by going to the CodeClimate Quality page for your repo (i.e. https://codeclimate.com/github/[organization]/[repo]). On the Repo Settings > Test Coverage page near the bottom there is a Recent Reports section and you should see a report appearing here when the workflow completes successfully.
+
+```yml
+name: Test Code Coverage (CodeClimate)
+on: [push]
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Run Automated testing + report coverage
+        uses: tripal/test-tripal-action@v1.6
+        with:
+          directory-name: my_tripal_extension
+          modules: my_tripal_extension
+          php-version: 8.3
+          pgsql-version: 16
+          drupal-version: 10.4.x-dev
+          codeclimate-reporter-id: ${{ secrets.CODECLIMATE_TEST_REPORTER_ID }}
 ```
 
 ## Inputs
@@ -75,9 +109,12 @@ A string to be appended to the end of the PHPUnit command. See the following exa
 - `--testsuite MyCustomTestSuite`: only run tests in a specific Test suite as configured in your phpunit.xml.
 - `--group MyGroupName`: runs tests with the "@group MyGroupName" added to their docblock headers.
 - `--filter testMySpecificMethod`: runs the testMySpecificMethod method specifically. This option can also be used to more generally filter your tests using regular expressions.
-- `--coverage-clover /var/www/drupal/web/modules/mydir/clover.xml`: to run code coverage with the output format matching that for CodeClimate and place the file in a specific directory.
 
 For a full listing of options for the PHPUnit [see the docs](https://docs.phpunit.de/en/9.6/textui.html).
+
+### `codeclimate-reporter-id`
+
+Provides the codeclimate reporter ID to report any code coverage to. You can find this ID by registering your repo for code climate and then going to Repo Settings > Test Coverage and copying the "Test Reporter ID". This ID should then be saved as a secret in your repository on Github by going to Settings > Secrets and Variables > Actions on your repos github page and adding a repository secret (e.g. `CODECLIMATE_TEST_REPORTER_ID`) where the value is the CodeClimate "Test Reporter ID". See the Test coverage example for more details on how to use this in your workflow.
 
 ### `build-image`
 

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} testing:localdocker
-          docker exec tripaldocker pg_isready --dbname=sitedb --timeout=5
+          docker exec tripaldocker pg_isready --dbname=sitedb --username=docker --timeout=25
       # Install the modules
       - name: Install our package in Docker
         if: "${{ inputs.modules != '' }}"

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} testing:localdocker
-          pg_isready -h localhost -p 5432 -t 5
+          docker exec tripaldocker pg_isready -h localhost -p 5432 -t 5
       # Install the modules
       - name: Install our package in Docker
         if: "${{ inputs.modules != '' }}"

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} testing:localdocker
-          docker exec tripaldocker pg_isready -h localhost -p 5432 -t 5
+          docker exec tripaldocker pg_isready --dbname=sitedb --timeout=5
       # Install the modules
       - name: Install our package in Docker
         if: "${{ inputs.modules != '' }}"

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: "A string providing any options you would like added to the phpunit command."
     required: false
     default: ' '
+  codeclimate-reporter-id:
+    description: the reporter ID for codeclimate to publish results to. This should be saved as a secret in your reporsitory.
+    required: false
   build-image:
     description: "Indicates whether you would like to build the docker based on your code (true) or pull an existing image (false)."
     required: true
@@ -67,8 +70,20 @@ runs:
         shell: bash
         run: |
           docker exec tripaldocker drush en ${{ inputs.modules }} --yes
-      # Runs the PHPUnit tests.
+      # If we have codeclimate enabled, then prepare for it here.
+      - name: Prepare for Codeclimate coverage reporting
+        if: "${{ inputs.codeclimate-reporter-id != '' }}"
+        shell: bash
+        env:
+          ABSOLUTE_MODULE_PATH: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}"
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          docker cp cc-test-reporter tripaldocker:$ABSOLUTE_MODULE_PATH
+          docker exec tripaldocker chmod a+x $ABSOLUTE_MODULE_PATH/cc-test-reporter
+          docker exec --workdir=$ABSOLUTE_MODULE_PATH tripaldocker ./cc-test-reporter before-build --debug
+      # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
+        if: "${{ inputs.codeclimate-reporter-id == '' }}"
         shell: bash
         env:
           SIMPLETEST_BASE_URL: "http://localhost"
@@ -80,3 +95,34 @@ runs:
             -e BROWSER_OUTPUT_DIRECTORY=$BROWSER_OUTPUT_DIRECTORY \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit ${{ inputs.phpunit-command-options }}
+      # Runs the PHPUnit tests WITH coverage.
+      - name: Run PHPUnit Tests with coverage for CodeClimate
+        if: "${{ inputs.codeclimate-reporter-id != '' }}"
+        shell: bash
+        env:
+          SIMPLETEST_BASE_URL: "http://localhost"
+          SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
+          BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
+          CODECLIMATE_REPORT: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}/clover.xml"
+        run: |
+          docker exec -e SIMPLETEST_BASE_URL=$SIMPLETEST_BASE_URL \
+            -e SIMPLETEST_DB=$SIMPLETEST_DB \
+            -e BROWSER_OUTPUT_DIRECTORY=$BROWSER_OUTPUT_DIRECTORY \
+            --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
+            tripaldocker phpunit ${{ inputs.phpunit-command-options }} \
+            --coverage-text --coverage-clover $CODECLIMATE_REPORT
+          docker exec tripaldocker ls /var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}
+      # Publish to codeclimate
+      - name: Publish code coverage to Code Climate
+        if: "${{ inputs.codeclimate-reporter-id != '' }}"
+        shell: bash
+        env:
+          CODECLIMATE_REPORT: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}/clover.xml"
+          ABSOLUTE_MODULE_PATH: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}"
+        run: |
+          docker exec --workdir=$ABSOLUTE_MODULE_PATH tripaldocker \
+            git config --global --add safe.directory $ABSOLUTE_MODULE_PATH
+          docker exec --workdir=$ABSOLUTE_MODULE_PATH \
+            tripaldocker ./cc-test-reporter after-build clover.xml \
+            --id ${{ inputs.codeclimate-reporter-id }} \
+            --debug -t clover -p $ABSOLUTE_MODULE_PATH

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ inputs:
   pgsql-version:
     description: "The version of PostgreSQL you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 13)."
     required: false
-    default: '13'
+    default: '16'
   drupal-version:
     description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 9.4.x-dev, 9.5.x-dev)."
     required: false
-    default: '10.2.x-dev'
+    default: '10.4.x-dev'
   phpunit-command-options:
     description: "A string providing any options you would like added to the phpunit command."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,7 @@ runs:
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} testing:localdocker
+          pg_isready -h localhost -p 5432 -t 5
       # Install the modules
       - name: Install our package in Docker
         if: "${{ inputs.modules != '' }}"

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   build-image:
     description: "Indicates whether you would like to build the docker based on your code (true) or pull an existing image (false)."
     required: true
-    default: false
+    default: 'false'
   dockerfile:
     description: "The relative path and file name for the dockerfile to use with build-image."
     required: true
@@ -48,19 +48,11 @@ runs:
         if: ${{ inputs.build-image == 'true' }}
         shell: bash
         run: |
-          TRIPALDOCKER="tripaldocker/Dockerfile-php${{ inputs.php-version }}"
-          if [ -f "${{ inputs.dockerfile }}" ]; then
             docker build --tag=testing:localdocker \
               --build-arg drupalversion="${{ inputs.drupal-version }}" \
               --build-arg phpversion="${{ inputs.php-version }}" \
-              --build-arg chadoschema='teacup' ./
-          elif [ -f "$TRIPALDOCKER" ]; then
-            docker build --tag=testing:localdocker \
-              --build-arg drupalversion="${{ inputs.drupal-version }}" \
               --build-arg postgresqlversion="${{ inputs.pgsql-version }}" \
-              --build-arg chadoschema='teacup' ./ \
-              --file $TRIPALDOCKER
-          fi
+              --build-arg chadoschema='teacup' ./
       # Just spin up docker the good ol' fashion way
       # mounting our currently checked out package inside the docker container.
       - name: Spin up Docker locally
@@ -73,7 +65,6 @@ runs:
         if: "${{ inputs.modules != '' }}"
         shell: bash
         run: |
-          docker exec tripaldocker service postgresql restart
           docker exec tripaldocker drush en ${{ inputs.modules }} --yes
       # Runs the PHPUnit tests.
       - name: Run PHPUnit Tests
@@ -83,7 +74,6 @@ runs:
           SIMPLETEST_DB: "pgsql://drupaladmin:drupaldevelopmentonlylocal@localhost/sitedb"
           BROWSER_OUTPUT_DIRECTORY: "/var/www/drupal/web/sites/default/files/simpletest"
         run: |
-          docker exec tripaldocker service postgresql restart
           docker exec -e SIMPLETEST_BASE_URL=$SIMPLETEST_BASE_URL \
             -e SIMPLETEST_DB=$SIMPLETEST_DB \
             -e BROWSER_OUTPUT_DIRECTORY=$BROWSER_OUTPUT_DIRECTORY \

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
             --volume=`pwd`:/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} testing:localdocker
-          docker exec tripaldocker pg_isready --dbname=sitedb --username=docker --timeout=25
+          docker exec tripaldocker bash -c "until pg_isready --dbname=sitedb --username=drupaladmin --host=localhost; do sleep 1; done"
       # Install the modules
       - name: Install our package in Docker
         if: "${{ inputs.modules != '' }}"


### PR DESCRIPTION
Name says it all really.

Adds a bit to check that PostgreSQL has come up fully. This is needed because it's now managed by Supervisord so we can't just wait for the service postgresql start command to complete. 

Also adds support for test coverage so we don't have to keep maintaining separate manual workflows for that.