### PR TITLE
Support different versions of PHPUnit seamlessly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           directory-name: tripal
           modules: tripal
-          php-version: "8.3"
+          php-version: "8.4"
           pgsql-version: "18"
-          drupal-version: "10.5.x-dev"
+          drupal-version: "11.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"
@@ -68,9 +68,9 @@ jobs:
         with:
           directory-name: tripal
           modules: tripal
-          php-version: "8.3"
-          pgsql-version: "16"
-          drupal-version: "11.1.x-dev"
+          php-version: "8.4"
+          pgsql-version: "18"
+          drupal-version: "11.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           modules: tripal
           php-version: "8.4"
           pgsql-version: "18"
-          drupal-version: "11.x-dev"
+          drupal-version: "11.2.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"
@@ -70,7 +70,7 @@ jobs:
           modules: tripal
           php-version: "8.4"
           pgsql-version: "18"
-          drupal-version: "11.x-dev"
+          drupal-version: "11.2.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,8 @@ jobs:
           directory-name: tripal
           modules: tripal
           php-version: "8.3"
-          pgsql-version: "16"
-          drupal-version: "10.4.x-dev"
+          pgsql-version: "18"
+          drupal-version: "10.5.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -84,15 +84,23 @@ runs:
         shell: bash
         run: |
           configfile='phpunit.xml'
+          echo "Default: $configfile"
           version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
           major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
-          if [ -n "$major_version" ]; then
-              versioned_file="phpunit.${major_version}.xml"
-              if [ -f "$versioned_file" ]; then
-                  configfile="$versioned_file"
-              else
-                echo "We checked for $versioned_file but it didn't exist."
-              fi
+          minor_version=$(echo "$version_str" | sed -E 's/^PHPUnit [0-9]+\.([0-9]+).*/\1/')
+          # Check for phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml)
+          versioned_file="phpunit.${major_version}.{minor_version}.xml"
+          if [ -f "$versioned_file" ]; then
+              configfile="$versioned_file"
+          else
+            echo "Option 1: $versioned_file --doesn't exist."
+          fi
+          # Check for phpunit.MAJOR.xml (e.g. phpunit.10.xml)
+          versioned_file="phpunit.${major_version}.xml"
+          if [ -f "$versioned_file" ]; then
+              configfile="$versioned_file"
+          else
+            echo "Option 2: $versioned_file --doesn't exist."
           fi
           echo "Using phpunit config file: $configfile"
           echo "configfile=$(echo $configfile)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ inputs:
     required: false
     default: '18'
   drupal-version:
-    description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.x-dev)."
+    description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.2.x-dev)."
     required: false
-    default: '11.x-dev'
+    default: '11.2.x-dev'
   phpunit-config:
    description: "The phpunit.xml file to configure the tests. If left blank, we will try to locate it using the following patters: (1) phpunit.VER.xml (where VER is 9 for drupal 10.4/5; 10 for drupal 11.1; 11 for drupal 11.2+), (2) phpunit.xml"
    required: false

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.1.x-dev)."
     required: false
     default: '11.1.x-dev'
+  phpunit-config:
+   description: "The phpunit.xml file to configure the tests. If left blank, we will try to locate it using the following patters: (1) phpunit.VER.xml (where VER is 9 for drupal 10.4/5; 10 for drupal 11.1; 11 for drupal 11.2+), (2) phpunit.xml"
+   required: false
   phpunit-command-options:
     description: "A string providing any options you would like added to the phpunit command."
     required: false
@@ -70,11 +73,32 @@ runs:
         shell: bash
         run: |
           docker exec tripaldocker drush en ${{ inputs.modules }} --yes
+      # Detect the PHPUnit config based on Drupal version.
+      - id: 'detect-phpunit-config'
+        name: "Detect version of phpunit"
+        if: "${{ inputs.phpunit-config == '' }}"
+        shell: bash
+        run: |
+          config_file='phpunit.xml'
+          version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
+          major_version=$(echo "$version_str" | grep -oP '(?<=PHPUnit )\d+')
+          if [ -n "$major_version" ]; then
+              versioned_file="phpunit.${major_version}.xml"
+              if [ -f "$versioned_file" ]; then
+                  config_file="$versioned_file"
+              else
+                echo "We checked for $versioned_file but it didn't exist."
+              fi
+          fi
+          echo "Using phpunit config file: $config_file"
+          echo "config_file=$config_file" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
+          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version
+          echo "Previously we detected that we should use ${{ steps.detect-phpunit-config.outputs.config_value }}"
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit ${{ inputs.phpunit-command-options }}

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
         run: |
           config_file='phpunit.xml'
           version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
-          major_version=$(echo "$version_str" | grep -oP '(?<=PHPUnit )\d+')
+          major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
           if [ -n "$major_version" ]; then
               versioned_file="phpunit.${major_version}.xml"
               if [ -f "$versioned_file" ]; then

--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,10 @@ inputs:
     description: "The relative path and file name for the dockerfile to use with build-image."
     required: true
     default: 'Dockerfile'
-outputs:
-  config_file:
-    description: 'The filename of the phpunit.xml configuration file to use.'
-    value: ${{ steps.detect-phpunit-config.outputs.config_file }}
+# outputs:
+#   config_file:
+#     description: 'The filename of the phpunit.xml configuration file to use.'
+#     value: ${{ steps.detect-phpunit-config.outputs.config_file }}
 runs:
   using: "composite"
   steps:
@@ -95,7 +95,6 @@ runs:
               fi
           fi
           echo "Using phpunit config file: $config_file"
-          echo "config_file=$config_file" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,15 @@ inputs:
   php-version:
     description: "The version of PHP you would like tested. This must match one of the current PHP versions TripalDocker is available in (e.g. 8.3)."
     required: false
-    default: '8.3'
+    default: '8.4'
   pgsql-version:
     description: "The version of PostgreSQL you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 13, 16)."
     required: false
-    default: '16'
+    default: '18'
   drupal-version:
-    description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.1.x-dev)."
+    description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.x-dev)."
     required: false
-    default: '11.1.x-dev'
+    default: '11.x-dev'
   phpunit-config:
    description: "The phpunit.xml file to configure the tests. If left blank, we will try to locate it using the following patters: (1) phpunit.VER.xml (where VER is 9 for drupal 10.4/5; 10 for drupal 11.1; 11 for drupal 11.2+), (2) phpunit.xml"
    required: false

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
         run: |
           config_file='phpunit.xml'
           version_str='PHPUnit 9.6.29 by Sebastian Bergmann and contributors.'
-          major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
+          major_version='9'
           if [ -n "$major_version" ]; then
               versioned_file="phpunit.${major_version}.xml"
               if [ -f "$versioned_file" ]; then

--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,10 @@ inputs:
     description: "The relative path and file name for the dockerfile to use with build-image."
     required: true
     default: 'Dockerfile'
-# outputs:
-#   config_file:
-#     description: 'The filename of the phpunit.xml configuration file to use.'
-#     value: ${{ steps.detect-phpunit-config.outputs.config_file }}
+outputs:
+  configfile:
+    description: 'The filename of the phpunit.xml configuration file to use.'
+    value: ${{ steps.detect-phpunit-config.outputs.configfile }}
 runs:
   using: "composite"
   steps:
@@ -84,15 +84,25 @@ runs:
         shell: bash
         run: |
           config_file='phpunit.xml'
-          version_str='PHPUnit 9.6.29 by Sebastian Bergmann and contributors.'
-          major_version='9'
+          version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
+          major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
+          if [ -n "$major_version" ]; then
+              versioned_file="phpunit.${major_version}.xml"
+              if [ -f "$versioned_file" ]; then
+                  config_file="$versioned_file"
+              else
+                echo "We checked for $versioned_file but it didn't exist."
+              fi
+          fi
+          echo "Using phpunit config file: $config_file"
+          echo "configfile=$(echo $config_file")" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
           docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version
-          echo "Previously we detected that we should use ${{ steps.detect-phpunit-config.outputs.config_value }}"
+          echo "Previously we detected that we should use '${{ steps.detect-phpunit-config.outputs.config_file }}'."
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit ${{ inputs.phpunit-command-options }}

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         shell: bash
         run: |
           config_file='phpunit.xml'
-          version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
+          version_str='PHPUnit 9.6.29 by Sebastian Bergmann and contributors.'
           major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
           if [ -n "$major_version" ]; then
               versioned_file="phpunit.${major_version}.xml"

--- a/action.yml
+++ b/action.yml
@@ -82,14 +82,8 @@ runs:
           config_file='phpunit.xml'
           version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
           major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
-          if [ -n "$major_version" ]; then
-              versioned_file="phpunit.${major_version}.xml"
-              if [ -f "$versioned_file" ]; then
-                  config_file="$versioned_file"
-              else
-                echo "We checked for $versioned_file but it didn't exist."
-              fi
-          fi
+          versioned_file="phpunit.${major_version}.xml"
+          echo "We checked for $versioned_file but it didn't exist."
           echo "Using phpunit config file: $config_file"
           echo "config_file=$config_file" >> "$GITHUB_OUTPUT"
       # Runs the PHPUnit tests without coverage.

--- a/action.yml
+++ b/action.yml
@@ -111,6 +111,7 @@ runs:
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
+          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker ls
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} ${{ inputs.phpunit-command-options }}
@@ -121,7 +122,6 @@ runs:
         env:
           COVERAGE_REPORT: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}/clover.xml"
         run: |
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker ls
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit \

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: "The relative path and file name for the dockerfile to use with build-image."
     required: true
     default: 'Dockerfile'
+outputs:
+  config_file:
+    description: 'The filename of the phpunit.xml configuration file to use.'
+    value: ${{ steps.detect-phpunit-config.outputs.config_file }}
 runs:
   using: "composite"
   steps:
@@ -82,10 +86,16 @@ runs:
           config_file='phpunit.xml'
           version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
           major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
-          versioned_file="phpunit.${major_version}.xml"
-          echo "We checked for $versioned_file but it didn't exist."
+          if [ -n "$major_version" ]; then
+              versioned_file="phpunit.${major_version}.xml"
+              if [ -f "$versioned_file" ]; then
+                  config_file="$versioned_file"
+              else
+                echo "We checked for $versioned_file but it didn't exist."
+              fi
+          fi
           echo "Using phpunit config file: $config_file"
-          echo "config_file=$config_file" >> "$GITHUB_OUTPUT"
+          echo "config_file=$config_file" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
               echo "Option 2: $versioned_file --doesn't exist."
             fi
           fi
-          echo "\nUsing phpunit config file: $configfile"
+          echo "Using phpunit config file: $configfile"
           echo "configfile=$(echo $configfile)" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
@@ -121,10 +121,12 @@ runs:
         env:
           COVERAGE_REPORT: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}/clover.xml"
         run: |
+          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker ls
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
-            tripaldocker phpunit ${{ inputs.phpunit-command-options }} \
+            tripaldocker phpunit \
             --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} \
+            ${{ inputs.phpunit-command-options }} \
             --coverage-text --coverage-clover $COVERAGE_REPORT
           ls
       # Publish to QLTY Cloud

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
               fi
           fi
           echo "Using phpunit config file: $config_file"
-          echo "configfile=$(echo $config_file")" >> $GITHUB_OUTPUT
+          echo "configfile=$(echo $config_file)" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"

--- a/action.yml
+++ b/action.yml
@@ -89,18 +89,18 @@ runs:
           major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
           minor_version=$(echo "$version_str" | sed -E 's/^PHPUnit [0-9]+\.([0-9]+).*/\1/')
           # Check for phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml)
-          versioned_file="phpunit.${major_version}.{minor_version}.xml"
+          versioned_file="phpunit.${major_version}.${minor_version}.xml"
           if [ -f "$versioned_file" ]; then
               configfile="$versioned_file"
           else
             echo "Option 1: $versioned_file --doesn't exist."
-          fi
-          # Check for phpunit.MAJOR.xml (e.g. phpunit.10.xml)
-          versioned_file="phpunit.${major_version}.xml"
-          if [ -f "$versioned_file" ]; then
-              configfile="$versioned_file"
-          else
-            echo "Option 2: $versioned_file --doesn't exist."
+            # Check for phpunit.MAJOR.xml (e.g. phpunit.10.xml)
+            versioned_file="phpunit.${major_version}.xml"
+            if [ -f "$versioned_file" ]; then
+                configfile="$versioned_file"
+            else
+              echo "Option 2: $versioned_file --doesn't exist."
+            fi
           fi
           echo "Using phpunit config file: $configfile"
           echo "configfile=$(echo $configfile)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -91,18 +91,20 @@ runs:
           # Check for phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml)
           versioned_file="phpunit.${major_version}.${minor_version}.xml"
           if [ -f "$versioned_file" ]; then
-              configfile="$versioned_file"
+            echo "Option 1: $versioned_file --found!"
+            configfile="$versioned_file"
           else
             echo "Option 1: $versioned_file --doesn't exist."
             # Check for phpunit.MAJOR.xml (e.g. phpunit.10.xml)
             versioned_file="phpunit.${major_version}.xml"
             if [ -f "$versioned_file" ]; then
+              echo "Option 2: $versioned_file --found!"
                 configfile="$versioned_file"
             else
               echo "Option 2: $versioned_file --doesn't exist."
             fi
           fi
-          echo "Using phpunit config file: $configfile"
+          echo "\nUsing phpunit config file: $configfile"
           echo "configfile=$(echo $configfile)" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,6 @@ runs:
           config_file='phpunit.xml'
           version_str='PHPUnit 9.6.29 by Sebastian Bergmann and contributors.'
           major_version='9'
-          echo "Using phpunit config file: $config_file"
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"

--- a/action.yml
+++ b/action.yml
@@ -86,14 +86,6 @@ runs:
           config_file='phpunit.xml'
           version_str='PHPUnit 9.6.29 by Sebastian Bergmann and contributors.'
           major_version='9'
-          if [ -n "$major_version" ]; then
-              versioned_file="phpunit.${major_version}.xml"
-              if [ -f "$versioned_file" ]; then
-                  config_file="$versioned_file"
-              else
-                echo "We checked for $versioned_file but it didn't exist."
-              fi
-          fi
           echo "Using phpunit config file: $config_file"
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests

--- a/action.yml
+++ b/action.yml
@@ -83,26 +83,26 @@ runs:
         if: "${{ inputs.phpunit-config == '' }}"
         shell: bash
         run: |
-          config_file='phpunit.xml'
+          configfile='phpunit.xml'
           version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
           major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
           if [ -n "$major_version" ]; then
               versioned_file="phpunit.${major_version}.xml"
               if [ -f "$versioned_file" ]; then
-                  config_file="$versioned_file"
+                  configfile="$versioned_file"
               else
                 echo "We checked for $versioned_file but it didn't exist."
               fi
           fi
-          echo "Using phpunit config file: $config_file"
-          echo "configfile=$(echo $config_file)" >> $GITHUB_OUTPUT
+          echo "Using phpunit config file: $configfile"
+          echo "configfile=$(echo $configfile)" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
           docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version
-          echo "Previously we detected that we should use '${{ steps.detect-phpunit-config.outputs.config_file }}'."
+          echo "Previously we detected that we should use '${{ steps.detect-phpunit-config.outputs.configfile }}'."
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit ${{ inputs.phpunit-command-options }}

--- a/action.yml
+++ b/action.yml
@@ -101,11 +101,9 @@ runs:
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version
-          echo "Previously we detected that we should use '${{ steps.detect-phpunit-config.outputs.configfile }}'."
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
-            tripaldocker phpunit ${{ inputs.phpunit-command-options }}
+            tripaldocker phpunit --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} ${{ inputs.phpunit-command-options }}
       # Runs the PHPUnit tests WITH coverage.
       - name: Run PHPUnit Tests with coverage for QLTY Cloud
         if: "${{ inputs.qltycloud-reporter-id != '' }}"
@@ -116,6 +114,7 @@ runs:
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
             tripaldocker phpunit ${{ inputs.phpunit-command-options }} \
+            --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} \
             --coverage-text --coverage-clover $COVERAGE_REPORT
           ls
       # Publish to QLTY Cloud

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
               fi
           fi
           echo "Using phpunit config file: $config_file"
-          echo "config_file=$config_file" >> $GITHUB_OUTPUT
+          echo "config_file=$config_file" >> "$GITHUB_OUTPUT"
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"


### PR DESCRIPTION
Issue #10 

Thanks to extended Drupal support, extension module testing grids often test across 2-3 versions of PHPUnit. For example, right now Drupal 10.4 and 10.5 use PHPUnit 9, Drupal 11.1 uses PHPUnit 10 and Drupal 11.2 and 11.3 use PHPUnit 11 🤪 

Unfortunately the phpunit.xml configuration seems to never be backwards compatible 🙈 

In Tripal Core we manage this by having a different version of the config for each PHPUnit version and then have added code in our workflow that determines which version of the config to use. This however is error prone, requires changes in multiple places and is hard to maintain.

## Implementation

This PR adds an new option `phpunit-config` to this action. If provided this will be passed to phpunit as the value to the `--configuration` options.

We also added a new step to the composite workflow which will attempt to provide a smart default if the new option is empty. More specifically, 

- step `detect-phpunit-config` 
  - captures the output of `phpunit --version` within the docker from previous steps.
  - extracts the major and minor version from this string
  - checks for a file of the format phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml) and if it exists then use it.
  - checks for a file of the format phpunit.MAJOR.xml (e.g. phpunit.10.xml) and if it exists then use it.
  - if both exist then the more specific phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml) is used
  - if neither exists then fallback to phpunit.xml
  - assigns whatever config file chosen to a step output: steps.detect-phpunit-config.outputs.configfile
- steps that run phpunit then use the output from above and assigns the `--configuration ${{ steps.detect-phpunit-config.outputs.configfile }}`
- configfile is also an output of the action so you can use it in following steps too!

## Testing

There are already github workflow runs testing this action.
A more specific test will be added as well.