### PR TITLE
Support different versions of PHPUnit seamlessly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           directory-name: tripal
           modules: tripal
-          php-version: "8.3"
-          pgsql-version: "16"
-          drupal-version: "10.4.x-dev"
+          php-version: "8.4"
+          pgsql-version: "18"
+          drupal-version: "11.2.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"
@@ -68,9 +68,9 @@ jobs:
         with:
           directory-name: tripal
           modules: tripal
-          php-version: "8.3"
-          pgsql-version: "16"
-          drupal-version: "11.1.x-dev"
+          php-version: "8.4"
+          pgsql-version: "18"
+          drupal-version: "11.2.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ on: [push]
 
 jobs:
   test_all_defaults:
-    name: "Run using all defaults"
+    name: "Tripal Core: Only Required Options"
     runs-on: ubuntu-latest
     steps:
       # To use this repository's private action,
@@ -23,7 +23,7 @@ jobs:
           modules: tripal
           phpunit-command-options: '--filter testTripalAdminPages'
   test_all_provided:
-    name: "Run providing all inputs"
+    name: "Tripal Core: Specify versions + build docker"
     runs-on: ubuntu-latest
     steps:
       # To use this repository's private action,
@@ -49,7 +49,7 @@ jobs:
           build-image: true
           dockerfile: "Dockerfile"
   test_qltycloud:
-    name: "Run providing inputs needed for qltycloud coverage reporting"
+    name: "Tripal Core: QltyCloud coverage reporting"
     runs-on: ubuntu-latest
     steps:
       # To use this repository's private action,
@@ -68,10 +68,5 @@ jobs:
         with:
           directory-name: tripal
           modules: tripal
-          php-version: "8.4"
-          pgsql-version: "18"
-          drupal-version: "11.2.x-dev"
           phpunit-command-options: '--filter testTripalAdminPages'
-          build-image: true
-          dockerfile: "Dockerfile"
           qltycloud-reporter-id: ${{ secrets.QLTY_COVERAGE_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,31 @@
-on: [push]
+name: 'Single Version Combo'
+
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   test_all_defaults:
-    name: "Tripal Core: Only Required Options"
+    name: "Only Required Options"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+        - id: tripal/tripal
+          directory: tripal
+          filter: testTripalAdminPages
+        - id: TripalCultivate/TripalCultivate
+          directory: TripalCultivate
+          filter: testPreprocessPage
     steps:
       # To use this repository's private action,
       # you must check out the repository
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Clone Tripal for testing purposes
+      - name: Clone Repo for testing purposes
         run: |
-          git clone https://github.com/tripal/tripal.git tmp
+          git clone https://github.com/${{ matrix.repo.id }}.git tmp
           cd tmp
           git checkout 4.x
           mv * ../
@@ -19,12 +33,22 @@ jobs:
       - name: Run the action step
         uses: ./ # Uses an action in the root directory
         with:
-          directory-name: tripal
-          modules: tripal
-          phpunit-command-options: '--filter testTripalAdminPages'
+          directory-name: ${{ matrix.repo.directory }}
+          phpunit-command-options: "--filter ${{ matrix.repo.filter }}"
+          build-image: true
   test_all_provided:
-    name: "Tripal Core: Specify versions + build docker"
+    name: "Specify versions + build docker"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+        - id: tripal/tripal
+          directory: tripal
+          filter: testTripalAdminPages
+        - id: TripalCultivate/TripalCultivate
+          directory: TripalCultivate
+          filter: testPreprocessPage
     steps:
       # To use this repository's private action,
       # you must check out the repository
@@ -32,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Clone Tripal for testing purposes
         run: |
-          git clone https://github.com/tripal/tripal.git tmp
+          git clone https://github.com/${{ matrix.repo.id }}.git tmp
           cd tmp
           git checkout 4.x
           mv * ../
@@ -40,17 +64,26 @@ jobs:
       - name: Run the action step
         uses: ./ # Uses an action in the root directory
         with:
-          directory-name: tripal
-          modules: tripal
+          directory-name: ${{ matrix.repo.directory }}
+          phpunit-command-options: "--filter ${{ matrix.repo.filter }}"
           php-version: "8.4"
           pgsql-version: "18"
           drupal-version: "11.2.x-dev"
-          phpunit-command-options: '--filter testTripalAdminPages'
           build-image: true
           dockerfile: "Dockerfile"
   test_qltycloud:
-    name: "Tripal Core: QltyCloud coverage reporting"
+    name: "QltyCloud coverage reporting"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+        - id: tripal/tripal
+          directory: tripal
+          filter: testTripalAdminPages
+        - id: TripalCultivate/TripalCultivate
+          directory: TripalCultivate
+          filter: testPreprocessPage
     steps:
       # To use this repository's private action,
       # you must check out the repository
@@ -58,7 +91,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Clone Tripal for testing purposes
         run: |
-          git clone https://github.com/tripal/tripal.git tmp
+          git clone https://github.com/${{ matrix.repo.id }}.git tmp
           cd tmp
           git checkout 4.x
           mv * ../
@@ -66,7 +99,7 @@ jobs:
       - name: Run the action step
         uses: ./ # Uses an action in the root directory
         with:
-          directory-name: tripal
-          modules: tripal
-          phpunit-command-options: '--filter testTripalAdminPages'
+          directory-name: ${{ matrix.repo.directory }}
+          phpunit-command-options: "--filter ${{ matrix.repo.filter }}"
           qltycloud-reporter-id: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          build-image: true

--- a/.github/workflows/matrixed.yml
+++ b/.github/workflows/matrixed.yml
@@ -1,0 +1,61 @@
+name: 'Matrixed'
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test_all_provided:
+    name: "Basic"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+        - id: tripal/tripal
+          directory: tripal
+          filter: testTripalAdminPages
+        - id: TripalCultivate/TripalCultivate
+          directory: TripalCultivate
+          filter: testPreprocessPage
+        php-version:
+          - '8.2'
+          - '8.3'
+          - '8.4'
+        pgsql-version:
+          - '18'
+        drupal-version:
+          - '10.5.x-dev'
+          - '11.1.x-dev'
+          - '11.x-dev'
+        exclude:
+          # Only Drupal 11.x supports PHP 8.4
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
+          # Drupal 11+ requires at least php 8.3.
+          - php-version: '8.2'
+            drupal-version: '11.1.x-dev'
+          - php-version: '8.2'
+            drupal-version: '11.x-dev'
+    steps:
+      # To use this repository's private action,
+      # you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Clone Tripal for testing purposes
+        run: |
+          git clone https://github.com/${{ matrix.repo.id }}.git tmp
+          cd tmp
+          git checkout 4.x
+          mv * ../
+          ls ../
+      - name: Run the action step
+        uses: ./ # Uses an action in the root directory
+        with:
+          directory-name: ${{ matrix.repo.directory }}
+          phpunit-command-options: "--filter ${{ matrix.repo.filter }}"
+          php-version: ${{ matrix.php-version }}
+          pgsql-version: ${{ matrix.pgsql-version }}
+          drupal-version: ${{ matrix.drupal-version }}
+          build-image: true
+          dockerfile: "Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -111,10 +111,11 @@ runs:
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
-          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker ls
-          docker exec \
-            --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
-            tripaldocker phpunit --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} ${{ inputs.phpunit-command-options }}
+          directory="/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}"
+          docker exec tripaldocker service postgresql restart
+          docker exec --workdir="$directory" tripaldocker phpunit \
+            --configuration "$directory/${{ steps.detect-phpunit-config.outputs.configfile }}" \
+            ${{ inputs.phpunit-command-options }}
       # Runs the PHPUnit tests WITH coverage.
       - name: Run PHPUnit Tests with coverage for QLTY Cloud
         if: "${{ inputs.qltycloud-reporter-id != '' }}"
@@ -122,10 +123,10 @@ runs:
         env:
           COVERAGE_REPORT: "/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}/clover.xml"
         run: |
-          docker exec \
-            --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
-            tripaldocker phpunit \
-            --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} \
+          directory="/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }}"
+          docker exec tripaldocker service postgresql restart
+          docker exec --workdir="$directory" tripaldocker phpunit \
+            --configuration "$directory/${{ steps.detect-phpunit-config.outputs.configfile }}" \
             ${{ inputs.phpunit-command-options }} \
             --coverage-text --coverage-clover $COVERAGE_REPORT
           ls

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,18 @@ inputs:
   php-version:
     description: "The version of PHP you would like tested. This must match one of the current PHP versions TripalDocker is available in (e.g. 8.3)."
     required: false
-    default: '8.3'
+    default: '8.4'
   pgsql-version:
     description: "The version of PostgreSQL you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 13, 16)."
     required: false
-    default: '16'
+    default: '18'
   drupal-version:
-    description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.1.x-dev)."
+    description: "The version of Drupal you would like your tests run against. This must match one of the current versions TripalDocker is available in (e.g. 11.2.x-dev)."
     required: false
-    default: '11.1.x-dev'
+    default: '11.2.x-dev'
+  phpunit-config:
+   description: "The phpunit.xml file to configure the tests. If left blank, we will try to locate it using the following patters: (1) phpunit.VER.xml (where VER is 9 for drupal 10.4/5; 10 for drupal 11.1; 11 for drupal 11.2+), (2) phpunit.xml"
+   required: false
   phpunit-command-options:
     description: "A string providing any options you would like added to the phpunit command."
     required: false
@@ -35,6 +38,10 @@ inputs:
     description: "The relative path and file name for the dockerfile to use with build-image."
     required: true
     default: 'Dockerfile'
+outputs:
+  configfile:
+    description: 'The filename of the phpunit.xml configuration file to use.'
+    value: ${{ steps.detect-phpunit-config.outputs.configfile }}
 runs:
   using: "composite"
   steps:
@@ -70,14 +77,44 @@ runs:
         shell: bash
         run: |
           docker exec tripaldocker drush en ${{ inputs.modules }} --yes
+      # Detect the PHPUnit config based on Drupal version.
+      - id: 'detect-phpunit-config'
+        name: "Detect version of phpunit"
+        if: "${{ inputs.phpunit-config == '' }}"
+        shell: bash
+        run: |
+          configfile='phpunit.xml'
+          echo "Default: $configfile"
+          version_str=$(docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker phpunit --version)
+          major_version=$(echo "$version_str" | sed -E 's/^PHPUnit ([0-9]+).*/\1/')
+          minor_version=$(echo "$version_str" | sed -E 's/^PHPUnit [0-9]+\.([0-9]+).*/\1/')
+          # Check for phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml)
+          versioned_file="phpunit.${major_version}.${minor_version}.xml"
+          if [ -f "$versioned_file" ]; then
+            echo "Option 1: $versioned_file --found!"
+            configfile="$versioned_file"
+          else
+            echo "Option 1: $versioned_file --doesn't exist."
+            # Check for phpunit.MAJOR.xml (e.g. phpunit.10.xml)
+            versioned_file="phpunit.${major_version}.xml"
+            if [ -f "$versioned_file" ]; then
+              echo "Option 2: $versioned_file --found!"
+                configfile="$versioned_file"
+            else
+              echo "Option 2: $versioned_file --doesn't exist."
+            fi
+          fi
+          echo "Using phpunit config file: $configfile"
+          echo "configfile=$(echo $configfile)" >> $GITHUB_OUTPUT
       # Runs the PHPUnit tests without coverage.
       - name: Run PHPUnit Tests
         if: "${{ inputs.qltycloud-reporter-id == '' }}"
         shell: bash
         run: |
+          docker exec --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} tripaldocker ls
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
-            tripaldocker phpunit ${{ inputs.phpunit-command-options }}
+            tripaldocker phpunit --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} ${{ inputs.phpunit-command-options }}
       # Runs the PHPUnit tests WITH coverage.
       - name: Run PHPUnit Tests with coverage for QLTY Cloud
         if: "${{ inputs.qltycloud-reporter-id != '' }}"
@@ -87,7 +124,9 @@ runs:
         run: |
           docker exec \
             --workdir=/var/www/drupal/web/modules/contrib/${{ inputs.directory-name }} \
-            tripaldocker phpunit ${{ inputs.phpunit-command-options }} \
+            tripaldocker phpunit \
+            --configuration ${{ steps.detect-phpunit-config.outputs.configfile }} \
+            ${{ inputs.phpunit-command-options }} \
             --coverage-text --coverage-clover $COVERAGE_REPORT
           ls
       # Publish to QLTY Cloud


### PR DESCRIPTION
Issue #10 

Thanks to extended Drupal support, extension module testing grids often test across 2-3 versions of PHPUnit. For example, right now Drupal 10.4 and 10.5 use PHPUnit 9, Drupal 11.1 uses PHPUnit 10 and Drupal 11.2 and 11.3 use PHPUnit 11 🤪 

Unfortunately the phpunit.xml configuration seems to never be backwards compatible 🙈 

In Tripal Core we manage this by having a different version of the config for each PHPUnit version and then have added code in our workflow that determines which version of the config to use. This however is error prone, requires changes in multiple places and is hard to maintain.

## Implementation

This PR adds an new option `phpunit-config` to this action. If provided this will be passed to phpunit as the value to the `--configuration` options.

We also added a new step to the composite workflow which will attempt to provide a smart default if the new option is empty. More specifically, 

- step `detect-phpunit-config` 
  - captures the output of `phpunit --version` within the docker from previous steps.
  - extracts the major and minor version from this string
  - checks for a file of the format phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml) and if it exists then use it.
  - checks for a file of the format phpunit.MAJOR.xml (e.g. phpunit.10.xml) and if it exists then use it.
  - if both exist then the more specific phpunit.MAJOR.MINOR.xml (e.g. phpunit.9.6.xml) is used
  - if neither exists then fallback to phpunit.xml
  - assigns whatever config file chosen to a step output: steps.detect-phpunit-config.outputs.configfile
- steps that run phpunit then use the output from above and assigns the `--configuration ${{ steps.detect-phpunit-config.outputs.configfile }}`
- configfile is also an output of the action so you can use it in following steps too!

## Testing

There are already github workflow runs testing this action.

I also added a matrixed test to check the three main drupal/phpunit combinations and that is all passing. As you can see in the following screenshots, it is correctly determining the PHPUnit xml to use for each version combination!

The following screenshots are obtained with this workflow step config:
```yml
      - name: Run the action step
        uses: ./ # Uses an action in the root directory
        with:
          directory-name: ${{ matrix.repo.directory }}
          phpunit-command-options: "--filter ${{ matrix.repo.filter }}"
          php-version: ${{ matrix.php-version }}
          pgsql-version: ${{ matrix.pgsql-version }}
          drupal-version: ${{ matrix.drupal-version }}
          build-image: true
          dockerfile: "Dockerfile"
```

<img width="813" height="756" alt="Drupal10 5 x-PHPUnit9" src="https://github.com/user-attachments/assets/df217fbc-1822-4042-8e76-07e8a9cdcb1c" />
<img width="808" height="762" alt="Drupal11 1 x-PHPUnit10" src="https://github.com/user-attachments/assets/68f7705d-3993-4e90-aa27-08bb89723de8" />
<img width="787" height="873" alt="Drupal11 x-PHPUnit11" src="https://github.com/user-attachments/assets/b374acdd-f40c-4893-8e01-a7b2067e1495" />
